### PR TITLE
Configure on kubeadm-master bash_completion for kubectl

### DIFF
--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -47,3 +47,13 @@
     owner: ubuntu
     group: ubuntu
     mode: 0600
+
+- name: Check for existing kubectl bash completion
+  stat:
+    path: /etc/bash_completion.d/kubectl
+  register: kubectl_bash_completion
+
+- name: Ensure kubectl bash_completion is present
+  become: True
+  shell: kubectl completion bash > /etc/bash_completion.d/kubectl
+  when: kubectl_bash_completion.stat.exists == False


### PR DESCRIPTION
I think this makes sense only on the master where you use the `kubectl` command