### PR TITLE
Workaround for gophercloud talking to Cinder API

### DIFF
--- a/files/cloud-config.j2
+++ b/files/cloud-config.j2
@@ -13,6 +13,7 @@ domain-name = {{ lookup('env', 'OS_DOMAIN_NAME') }}
 
 [BlockStorage]
 trust-device-path = false
+bs-version = v2
 
 {% if lookup('env', 'FLOATING_IP_NETWORK_UUID') != '' %}
 [LoadBalancer]

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -19,7 +19,7 @@
     token: "{{ token1 if kubelet_conf.stat.exists == False else token2 }}"
 
 - name: kubeadm init
-  command: "kubeadm init --skip-preflight-checks --token {{ token.stdout }} --kubernetes-version v1.7.0 --apiserver-advertise-address {{ hostvars[groups.master[0]].ansible_ssh_host }}"
+  command: "kubeadm init --skip-preflight-checks --token {{ token.stdout }} --kubernetes-version v1.7.4 --apiserver-advertise-address {{ hostvars[groups.master[0]].ansible_ssh_host }}"
   args:
     creates: /etc/kubernetes/kubelet.conf
 

--- a/roles/kubeadm/tasks/main.yaml
+++ b/roles/kubeadm/tasks/main.yaml
@@ -15,9 +15,9 @@
     update_cache: yes
   with_items:
     - docker.io=1.12.6-0ubuntu1~16.04.1
-    - kubelet=1.7.0-00
-    - kubeadm=1.7.0-00
-    - kubectl=1.7.0-00
+    - kubelet=1.7.4-00
+    - kubeadm=1.7.4-00
+    - kubectl=1.7.4-00
     - kubernetes-cni=0.5.1-00
 
 - name: add hosts

--- a/roles/kubeadm/tasks/master.yaml
+++ b/roles/kubeadm/tasks/master.yaml
@@ -19,7 +19,7 @@
     token: "{{ token1 if kubelet_conf.stat.exists == False else token2 }}"
 
 - name: kubeadm init
-  command: "kubeadm init --skip-preflight-checks --token {{ token.stdout }} --kubernetes-version v1.7.0 --apiserver-advertise-address {{ hostvars[groups.nodes[0]].ansible_ssh_host }}"
+  command: "kubeadm init --skip-preflight-checks --token {{ token.stdout }} --kubernetes-version v1.7.4 --apiserver-advertise-address {{ hostvars[groups.nodes[0]].ansible_ssh_host }}"
   args:
     creates: /etc/kubernetes/kubelet.conf
 


### PR DESCRIPTION
Since the playbook installs v1.7.0 the Cinder interaction is broken:

https://github.com/kubernetes/kubernetes/issues/49414