### PR TITLE
Fix broken 404 link to kubernetes-dashboard.yaml

### DIFF
--- a/roles/k8s-addons/tasks/main.yaml
+++ b/roles/k8s-addons/tasks/main.yaml
@@ -2,7 +2,7 @@
   command: kubectl apply -f https://git.io/weave-kube-1.6
 
 - name: kubectl apply dashboard
-  command: kubectl apply -f https://rawgit.com/kubernetes/dashboard/master/src/deploy/kubernetes-dashboard.yaml
+  command: kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/master/src/deploy/recommended/kubernetes-dashboard.yaml
 
 - name: copy manifests
   copy:


### PR DESCRIPTION
The old link is broken because of changes in the upstream k8s repo