### PR TITLE
docker: use the journald driver as the default logging driver

### DIFF
--- a/roles/kubeadm/handlers/main.yaml
+++ b/roles/kubeadm/handlers/main.yaml
@@ -3,3 +3,9 @@
     state: restarted
     daemon_reload: yes
     name: kubelet
+
+- name: Restart docker
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: docker

--- a/roles/kubeadm/tasks/main.yaml
+++ b/roles/kubeadm/tasks/main.yaml
@@ -20,6 +20,19 @@
     - kubectl=1.7.0-00
     - kubernetes-cni=0.5.1-00
 
+- name: configure docker to use journald
+  copy:
+    content: |
+      {
+        "log-driver": "journald"
+      }
+    dest: /etc/docker/daemon.json
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - Restart docker
+
 - name: add hosts
   lineinfile:
     dest: "/etc/hosts"


### PR DESCRIPTION
https://docs.docker.com/engine/admin/logging/journald/#usage

It is better to use this log driver in a K8s installation, because nothing gets written to the disk of the VMs. You should then use something like fluentd to collect the logs.
