### PR TITLE
Cloud provider openstack rebased for infraly

### DIFF
--- a/files/10-kubeadm.conf
+++ b/files/10-kubeadm.conf
@@ -7,4 +7,4 @@ Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/e
 Environment="KUBELET_CADVISOR_ARGS=--cadvisor-port=0"
 Environment="KUBELET_CERTIFICATE_ARGS=--rotate-certificates=true --cert-dir=/var/lib/kubelet/pki"
 ExecStart=
-ExecStart=/usr/bin/kubelet --cloud-provider=openstack --cloud-config=/etc/kubernetes/cloud-config $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_CADVISOR_ARGS $KUBELET_CERTIFICATE_ARGS $KUBELET_EXTRA_ARGS
+ExecStart=/usr/bin/kubelet --cloud-provider=external $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_CADVISOR_ARGS $KUBELET_CERTIFICATE_ARGS $KUBELET_EXTRA_ARGS

--- a/files/k8s-keystone-auth.yaml.j2
+++ b/files/k8s-keystone-auth.yaml.j2
@@ -20,7 +20,7 @@ spec:
     - /etc/kubernetes/pki/apiserver.key
     - --keystone-url
     - {{ lookup('env','OS_AUTH_URL') | replace("v2.0","v3") }}
-    image: k8scloudprovider/k8s-keystone-auth
+    image: k8scloudprovider/k8s-keystone-auth:v0.1.0
     imagePullPolicy: Always
     name: k8s-keystone-auth
     resources:

--- a/files/k8s-keystone-auth.yaml.j2
+++ b/files/k8s-keystone-auth.yaml.j2
@@ -20,17 +20,8 @@ spec:
     - /etc/kubernetes/pki/apiserver.key
     - --keystone-url
     - {{ lookup('env','OS_AUTH_URL') | replace("v2.0","v3") }}
-    image: zioproto/k8s-keystone-auth
+    image: k8scloudprovider/k8s-keystone-auth
     imagePullPolicy: Always
-    #livenessProbe:
-    #  failureThreshold: 8
-    #  httpGet:
-    #    host: 127.0.0.1
-    #    path: /healthz
-    #    port: 6443
-    #    scheme: HTTPS
-    #  initialDelaySeconds: 15
-    #  timeoutSeconds: 15
     name: k8s-keystone-auth
     resources:
       requests:

--- a/files/kube-controller-manager.yaml
+++ b/files/kube-controller-manager.yaml
@@ -22,11 +22,11 @@ spec:
     - --controllers=*,bootstrapsigner,tokencleaner
     - --service-account-private-key-file=/etc/kubernetes/pki/sa.key
     - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
-    - --cloud-provider=openstack
-    - --cloud-config=/etc/kubernetes/cloud-config
     - --allocate-node-cidrs=true
     - --cluster-cidr=10.96.0.0/16
+    - --cloud-provider=external
     image: gcr.io/google_containers/kube-controller-manager-amd64:v1.10.2
+>>>>>>> Use cloud-provider=external
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/files/kube-controller-manager.yaml
+++ b/files/kube-controller-manager.yaml
@@ -25,7 +25,9 @@ spec:
     - --allocate-node-cidrs=true
     - --cluster-cidr=10.96.0.0/16
     - --cloud-provider=external
-    image: gcr.io/google_containers/kube-controller-manager-amd64:v1.10.2
+    - --allocate-node-cidrs=true
+    - --cluster-cidr=10.96.0.0/16
+    image: gcr.io/google_containers/kube-controller-manager-amd64:v1.10.3
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/files/kube-controller-manager.yaml
+++ b/files/kube-controller-manager.yaml
@@ -26,7 +26,6 @@ spec:
     - --cluster-cidr=10.96.0.0/16
     - --cloud-provider=external
     image: gcr.io/google_containers/kube-controller-manager-amd64:v1.10.2
->>>>>>> Use cloud-provider=external
     livenessProbe:
       failureThreshold: 8
       httpGet:

--- a/files/openstack-cloud-controller-manager-pod.yaml
+++ b/files/openstack-cloud-controller-manager-pod.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: openstack-cloud-controller-manager
-      image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:latest
+      image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v0.1.0
       args:
         - /bin/openstack-cloud-controller-manager
         - --v=2

--- a/files/openstack-cloud-controller-manager-pod.yaml
+++ b/files/openstack-cloud-controller-manager-pod.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    component: kube-controller-manager
+    tier: control-plane
+  name: openstack-cloud-controller-manager
+  namespace: kube-system
+spec:
+  containers:
+    - name: openstack-cloud-controller-manager
+      image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:latest
+      args:
+        - /bin/openstack-cloud-controller-manager
+        - --v=2
+        - --allocate-node-cidrs=true
+        - --cluster-cidr=10.96.0.0/16
+        - --cloud-config=/etc/kubernetes/cloud-config
+        - --cloud-provider=openstack
+        - --use-service-account-credentials=true
+        - --address=127.0.0.1
+        - --kubeconfig=/etc/kubernetes/controller-manager.conf
+      volumeMounts:
+        - mountPath: /etc/kubernetes/pki
+          name: k8s-certs
+          readOnly: true
+        - mountPath: /etc/ssl/certs
+          name: ca-certs
+          readOnly: true
+        - mountPath: /etc/kubernetes/controller-manager.conf
+          name: kubeconfig
+          readOnly: true
+        - mountPath: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+          name: flexvolume-dir
+        - mountPath: /etc/kubernetes/cloud-config
+          name: cloud-config
+          readOnly: true
+      resources:
+        requests:
+          cpu: 200m
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /usr/libexec/kubernetes/kubelet-plugins/volume/exec
+      type: DirectoryOrCreate
+    name: flexvolume-dir
+  - hostPath:
+      path: /etc/kubernetes/pki
+      type: DirectoryOrCreate
+    name: k8s-certs
+  - hostPath:
+      path: /etc/ssl/certs
+      type: DirectoryOrCreate
+    name: ca-certs
+  - hostPath:
+      path: /etc/kubernetes/controller-manager.conf
+      type: FileOrCreate
+    name: kubeconfig
+  - hostPath:
+      path: /etc/kubernetes/cloud-config
+      type: FileOrCreate
+    name: cloud-config

--- a/roles/k8s-addons/files/syncconfig.yaml
+++ b/roles/k8s-addons/files/syncconfig.yaml
@@ -1,0 +1,11 @@
+# In format %d, %n and %i wildcards repesent keystone domain id, project name and id respectively
+# WARNING: If exceeds the maximum possible length of 63 characters, just Keystone project uuid will be used as the namespace name.
+
+#namespace_format: "prefix-%d-%n-%i-suffix"
+namespace_format: "keystone-%n"
+
+# List of Keystone project ids to omit from syncing
+projects_black_list: ["id1", "id2"]
+
+# List of data types to synchronize
+"data_types_to_sync": ["projects","role_assignments"]

--- a/roles/k8s-addons/files/syncconfig.yaml
+++ b/roles/k8s-addons/files/syncconfig.yaml
@@ -1,8 +1,10 @@
 # In format %d, %n and %i wildcards repesent keystone domain id, project name and id respectively
 # WARNING: If exceeds the maximum possible length of 63 characters, just Keystone project uuid will be used as the namespace name.
 
+# WARNING: a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
+
 #namespace_format: "prefix-%d-%n-%i-suffix"
-namespace_format: "keystone-%n"
+namespace_format: "keystone-%i"
 
 # List of Keystone project ids to omit from syncing
 projects_black_list: ["id1", "id2"]

--- a/roles/k8s-addons/tasks/main.yaml
+++ b/roles/k8s-addons/tasks/main.yaml
@@ -6,8 +6,17 @@
     src: "{{ role_path }}/files/manifests/"
     dest: "/home/ubuntu/manifests/"
 
+
+- name: Upload webook kubeconfig file
+  template:
+    dest: /home/ubuntu/manifests/k8s-keystone-auth.yaml
+    src: "{{ role_path }}/templates/k8s-keystone-auth.yaml.j2"
+
 - name: kubectl apply nginx-ingress-controller
   command: kubectl apply -f /home/ubuntu/manifests/nginx-ingress-controller.yaml
 
 - name: kubectl apply admin-user for dashboard
   command: kubectl apply -f /home/ubuntu/manifests/admin-user.yaml
+
+- name: kubectl apply k8s-keystone-auth
+  command: kubectl apply -f /home/ubuntu/manifests/k8s-keystone-auth.yaml

--- a/roles/k8s-addons/tasks/main.yaml
+++ b/roles/k8s-addons/tasks/main.yaml
@@ -18,5 +18,11 @@
 - name: kubectl apply admin-user for dashboard
   command: kubectl apply -f /home/ubuntu/manifests/admin-user.yaml
 
+- name: copy syncconfig.yaml
+  become: true
+  copy:
+   src: "{{ role_path }}/files/syncconfig.yaml"
+   dest: "/etc/kubernetes/syncconfig.yaml"
+
 - name: kubectl apply k8s-keystone-auth
   command: kubectl apply -f /home/ubuntu/manifests/k8s-keystone-auth.yaml

--- a/roles/k8s-addons/templates/k8s-keystone-auth.yaml.j2
+++ b/roles/k8s-addons/templates/k8s-keystone-auth.yaml.j2
@@ -20,7 +20,9 @@ spec:
     - /etc/kubernetes/pki/apiserver.key
     - --keystone-url
     - {{ lookup('env','OS_AUTH_URL') | replace("v2.0","v3") }}
-    image: k8scloudprovider/k8s-keystone-auth:v0.1.0
+    - --policy-configmap-name
+    - k8s-auth-policy
+    image: lingxiankong/k8s-keystone-auth:configmap-on-the-fly
     imagePullPolicy: Always
     name: k8s-keystone-auth
     resources:
@@ -33,6 +35,13 @@ spec:
     - mountPath: /etc/ssl/certs
       name: ca-certs
       readOnly: true
+  serviceAccount: admin-user
+  serviceAccountName: admin-user
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  tolerations:
+  - key: node-role.kubernetes.io/master
+    effect: NoSchedule
   hostNetwork: true
   volumes:
   - hostPath:

--- a/roles/k8s-addons/templates/k8s-keystone-auth.yaml.j2
+++ b/roles/k8s-addons/templates/k8s-keystone-auth.yaml.j2
@@ -22,14 +22,16 @@ spec:
     - {{ lookup('env','OS_AUTH_URL') | replace("v2.0","v3") }}
     - --policy-configmap-name
     - k8s-auth-policy
-    image: lingxiankong/k8s-keystone-auth:configmap-on-the-fly
+    - --sync-config-file
+    - /etc/kubernetes/syncconfig.yaml
+    image: zioproto/k8s-keystone-auth:e0fce6d3-dirty
     imagePullPolicy: Always
     name: k8s-keystone-auth
     resources:
       requests:
         cpu: 250m
     volumeMounts:
-    - mountPath: /etc/kubernetes/pki
+    - mountPath: /etc/kubernetes
       name: k8s-certs
       readOnly: true
     - mountPath: /etc/ssl/certs
@@ -45,7 +47,7 @@ spec:
   hostNetwork: true
   volumes:
   - hostPath:
-      path: /etc/kubernetes/pki
+      path: /etc/kubernetes
       type: DirectoryOrCreate
     name: k8s-certs
   - hostPath:

--- a/roles/k8s-addons/templates/k8s-keystone-auth.yaml.j2
+++ b/roles/k8s-addons/templates/k8s-keystone-auth.yaml.j2
@@ -1,57 +1,58 @@
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  annotations:
-    scheduler.alpha.kubernetes.io/critical-pod: ""
-  creationTimestamp: null
   labels:
-    component: k8s-keystone-auth
-    tier: control-plane
+    k8s-app: k8s-keystone-auth
   name: k8s-keystone-auth
   namespace: kube-system
 spec:
-  containers:
-  - command:
-    - ./bin/k8s-keystone-auth
-    - --tls-cert-file
-    - /etc/kubernetes/pki/apiserver.crt
-    - --tls-private-key-file
-    - /etc/kubernetes/pki/apiserver.key
-    - --keystone-url
-    - {{ lookup('env','OS_AUTH_URL') | replace("v2.0","v3") }}
-    - --policy-configmap-name
-    - k8s-auth-policy
-    - --sync-config-file
-    - /etc/kubernetes/syncconfig.yaml
-    image: zioproto/k8s-keystone-auth:e0fce6d3-dirty
-    imagePullPolicy: Always
-    name: k8s-keystone-auth
-    resources:
-      requests:
-        cpu: 250m
-    volumeMounts:
-    - mountPath: /etc/kubernetes
-      name: k8s-certs
-      readOnly: true
-    - mountPath: /etc/ssl/certs
-      name: ca-certs
-      readOnly: true
-  serviceAccount: admin-user
-  serviceAccountName: admin-user
-  nodeSelector:
-    node-role.kubernetes.io/master: ""
-  tolerations:
-  - key: node-role.kubernetes.io/master
-    effect: NoSchedule
-  hostNetwork: true
-  volumes:
-  - hostPath:
-      path: /etc/kubernetes
-      type: DirectoryOrCreate
-    name: k8s-certs
-  - hostPath:
-      path: /etc/ssl/certs
-      type: DirectoryOrCreate
-    name: ca-certs
-status: {}
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-keystone-auth
+  template:
+    metadata:
+      labels:
+        app: k8s-keystone-auth
+    spec:
+      hostNetwork: True
+      serviceAccount: admin-user
+      serviceAccountName: admin-user
+      containers:
+        - image: zioproto/k8s-keystone-auth:e0fce6d3-dirty
+          imagePullPolicy: Always
+          name: k8s-keystone-auth
+          args:
+            - ./bin/k8s-keystone-auth
+            - --tls-cert-file
+            - /etc/kubernetes/pki/apiserver.crt
+            - --tls-private-key-file
+            - /etc/kubernetes/pki/apiserver.key
+            - --keystone-url
+            - {{ lookup('env','OS_AUTH_URL') | replace("v2.0","v3") }}
+            - --policy-configmap-name
+            - k8s-auth-policy
+            - --sync-config-file
+            - /etc/kubernetes/syncconfig.yaml
+          volumeMounts:
+          - mountPath: /etc/kubernetes
+            name: k8s-certs
+            readOnly: true
+          - mountPath: /etc/ssl/certs
+            name: ca-certs
+            readOnly: true
+      volumes:
+      - hostPath:
+          path: /etc/kubernetes
+          type: DirectoryOrCreate
+        name: k8s-certs
+      - hostPath:
+          path: /etc/ssl/certs
+          type: DirectoryOrCreate
+        name: ca-certs
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule

--- a/roles/k8s-rbac/files/cloud-controller-manager-role-bindings.yaml
+++ b/roles/k8s-rbac/files/cloud-controller-manager-role-bindings.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-node-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-node-controller
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-node-controller
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:pvl-controller
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:pvl-controller
+  subjects:
+  - kind: ServiceAccount
+    name: pvl-controller
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: system:cloud-controller-manager
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: system:cloud-controller-manager
+  subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system
+kind: List
+metadata: {}

--- a/roles/k8s-rbac/files/cloud-controller-manager-roles.yaml
+++ b/roles/k8s-rbac/files/cloud-controller-manager-roles.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+items:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: cloud-controller-manager
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:cloud-node-controller
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - delete
+    - get
+    - patch
+    - update
+    - list
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: system:pvl-controller
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - persistentvolumes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+kind: List
+metadata: {}

--- a/roles/k8s-rbac/files/k8s-auth-policy.yaml
+++ b/roles/k8s-rbac/files/k8s-auth-policy.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-auth-policy
+  namespace: kube-system
+data:
+  policies: |
+    [
+    ]

--- a/roles/k8s-rbac/tasks/main.yaml
+++ b/roles/k8s-rbac/tasks/main.yaml
@@ -9,3 +9,7 @@
 
 - name: kubectl apply RBAC role bindings
   command: kubectl apply -f /home/ubuntu/manifests/cloud-controller-manager-role-bindings.yaml
+
+- name: apply k8s-auth-policy.yaml
+  command: kubectl apply -f /home/ubuntu/manifests/k8s-auth-policy.yaml
+

--- a/roles/k8s-rbac/tasks/main.yaml
+++ b/roles/k8s-rbac/tasks/main.yaml
@@ -1,0 +1,11 @@
+---
+- name: copy manifests
+  copy:
+    src: "{{ role_path }}/files/"
+    dest: "/home/ubuntu/manifests/"
+
+- name: kubectl apply RBAC roles
+  command: kubectl apply -f /home/ubuntu/manifests/cloud-controller-manager-roles.yaml
+
+- name: kubectl apply RBAC role bindings
+  command: kubectl apply -f /home/ubuntu/manifests/cloud-controller-manager-role-bindings.yaml

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -17,6 +17,11 @@
   set_fact:
     joincommand: "{{ joincommand.stdout }}"
 
+- name: Upload the openstack-cloud-controller-manager pod descriptor
+  copy:
+    dest: /etc/kubernetes/manifests/openstack-cloud-controller-manager-pod.yaml
+    src: files/openstack-cloud-controller-manager-pod.yaml
+
 - name: Configure kube-controller-manager cloud provider integration
   copy:
     dest: /etc/kubernetes/manifests/kube-controller-manager.yaml

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -4,7 +4,7 @@
   register: kubelet_conf
 
 - name: kubeadm init
-  command: "kubeadm init --kubernetes-version v1.10.2 --apiserver-advertise-address {{ hostvars[groups.master[0]].ansible_ssh_host }}"
+  command: "kubeadm init --kubernetes-version v1.10.3 --apiserver-advertise-address {{ hostvars[groups.master[0]].ansible_ssh_host }}"
   args:
     creates: /etc/kubernetes/kubelet.conf
   when: kubelet_conf.stat.exists == False
@@ -47,19 +47,19 @@
   replace:
     path: /etc/kubernetes/manifests/kube-apiserver.yaml
     regexp: v1.[0-9]{1,2}.[0-9]{1,2}
-    replace: v1.10.2
+    replace: v1.10.3
 
 - name: In case of upgrade make sure container versions are right for kube-controller-manager
   replace:
     path: /etc/kubernetes/manifests/kube-controller-manager.yaml
     regexp: v1.[0-9]{1,2}.[0-9]{1,2}
-    replace: v1.10.2
+    replace: v1.10.3
 
 - name: In case of upgrade make sure container versions are right for kube-scheduler
   replace:
     path: /etc/kubernetes/manifests/kube-scheduler.yaml
     regexp: v1.[0-9]{1,2}.[0-9]{1,2}
-    replace: v1.10.2
+    replace: v1.10.3
 
 - name: Ensure kubectl configuration directory is present
   become: True

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -32,15 +32,10 @@
     dest: /etc/kubernetes/pki/webhook.kubeconfig.yaml
     src: files/webhook.kubeconfig.yaml
 
-- name: Upload webook kubeconfig file
-  template:
-    dest: /etc/kubernetes/manifests/k8s-keystone-auth.yaml
-    src: files/k8s-keystone-auth.yaml.j2
-
 - name: Configure keystone integration
   blockinfile:
     insertbefore: 'image: '
-    block: "    - --authentication-token-webhook-config-file=/etc/kubernetes/pki/webhook.kubeconfig.yaml"
+    block: "    - --authentication-token-webhook-config-file=/etc/kubernetes/pki/webhook.kubeconfig.yaml\n    - --authorization-mode=Node,Webhook,RBAC\n    - --authorization-webhook-config-file=/etc/kubernetes/pki/webhook.kubeconfig.yaml"
     path: /etc/kubernetes/manifests/kube-apiserver.yaml
 
 - name: In case of upgrade make sure container versions are right for kube-apiserver

--- a/roles/kubeadm/tasks/main.yaml
+++ b/roles/kubeadm/tasks/main.yaml
@@ -26,9 +26,9 @@
     update_cache: yes
   with_items:
     - docker-engine=1.12.6-0~ubuntu-xenial
-    - kubelet=1.10.2-00
-    - kubeadm=1.10.2-00
-    - kubectl=1.10.2-00
+    - kubelet=1.10.3-00
+    - kubeadm=1.10.3-00
+    - kubectl=1.10.3-00
     - kubernetes-cni=0.6.0-00
 
 - name: configure docker to use journald

--- a/site.yaml
+++ b/site.yaml
@@ -82,6 +82,13 @@
   roles:
     - kubeadm-nodes
 
+- name: k8s rbac
+  hosts: master
+  tags:
+    - bootstrap
+  roles:
+    - k8s-rbac
+
 - name: k8s addons
   hosts: master
   tags:


### PR DESCRIPTION
Hello @ctrlaltdel ,

this PR makes possible to use the external cloud-provider-openstack

Running the kubelet with `--cloud-provider=openstack` is deprecated. This patch uses the new external controller.