### PR TITLE
Add volume support for nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,15 @@ The following optional environment variables can also be set:
   * `NODE_COUNT`: how many nodes should we provision, defaults to 3
   * `NODE_AUTO_IP` assign a floating IP to nodes, defaults to False
   * `NODE_DELETE_FIP`: delete floating IP when node is destroyed, defaults to True
+  * `NODE_BOOT_FROM_VOLUME`: boot node instances using boot from volume. Useful on clouds with only boot from volume
+  * `NODE_TERMINATE_VOLUME`: delete the root volume when each node instance is destroy, defaults to True
+  * `NODE_VOLUME_SIZE`: size of each node volume. defaults to 64GB
+  * `NODE_EXTRA_VOLUME`: create an extra unmounted data volume for each node, defaults to False
+  * `NODE_EXTRA_VOLUME_SIZE`: size of extra data volume for each node, defaults to 80GB
+  * `NODE_DELETE_EXTRA_VOLUME`: delete the extra data volume for each node when node is destroy, defaults to True
   * `MASTER_BOOT_FROM_VOLUME`: boot the master instance on a volume for data persistence, defaults to True
   * `MASTER_TERMINATE_VOLUME`: delete the volume when master instance is destroy, defaults to True
-  * `MASTER_VOLUME_SIZE`: size of the master volume
+  * `MASTER_VOLUME_SIZE`: size of the master volume. default to 64GB
   * `MASTER_MEMORY`: how many MB of memory should master have, defaults to 4 GB
   * `MASTER_FLAVOR`: allows to configure the exact OpenStack flavor name or ID to use for the master. When set, the `MASTER_MEMORY` setting is ignored.
   * `INCLUDE_HELM`: installs helm to the cluster, defaults to False

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -23,6 +23,15 @@ nodes_flavor_ram: "{{ lookup('env','NODE_MEMORY') | default('4096', true) }}"
 nodes_flavor_name: "{{ lookup('env','NODE_FLAVOR') | default(false) }}"
 nodes_auto_ip: "{{ lookup('env', 'NODE_AUTO_IP') | default ('False', true) }}"
 nodes_delete_fip: "{{ lookup('env', 'NODE_DELETE_FIP') | default ('True', true) }}"
+# Some clouds only support boot from volume - use it even for ephemeral nodes
+nodes_boot_from_volume: "{{ lookup('env', 'NODE_BOOT_FROM_VOLUME') | default('False', true) }}"
+nodes_terminate_volume: "{{ lookup('env', 'NODE_TERMINATE_VOLUME') | default('True', true) }}"
+nodes_volume_size: "{{ lookup('env', 'NODE_VOLUME_SIZE') | default('64', true) }}"
+# Whether to attach a data volume to each node. Useful when running Ceph via rook
+nodes_extra_volume: "{{ lookup('env', 'NODE_EXTRA_VOLUME') | default('True', true) }}"
+nodes_extra_volume_name: "{{ name }}-data-" # node id will automatically be appended
+nodes_extra_volume_size: "{{ lookup('env', 'NODE_EXTRA_VOLUME_SIZE') | default('80', true) }}"
+nodes_delete_extra_volume: "{{ lookup('env', 'NODE_DELETE_EXTRA_VOLUME') | default('True', true) }}"
 
 helm_include: "{{ lookup('env', 'INCLUDE_HELM') | default(false) }}"
 helm_repos: "{{ lookup('env', 'HELM_REPOS').split(';') | default([], true) }}"

--- a/roles/openstack-nodes/tasks/main.yaml
+++ b/roles/openstack-nodes/tasks/main.yaml
@@ -10,6 +10,9 @@
     key_name: "{{ key_name }}"
     flavor_ram: "{{ nodes_flavor_ram if not nodes_flavor_name else omit }}"
     flavor: "{{ nodes_flavor_name if nodes_flavor_name else omit }}"
+    boot_from_volume: "{{ nodes_boot_from_volume }}"
+    terminate_volume: "{{ nodes_terminate_volume }}"
+    volume_size: "{{ nodes_volume_size }}"
     nics:
       - net-name: "{{ network_name }}"
     auto_ip: "{{ nodes_auto_ip }}"
@@ -26,11 +29,40 @@
   register: "instances"
   with_sequence: count={{ nodes_count }}
 
+- name: Create data volumes for minions
+  os_volume:
+    name: "{{ nodes_extra_volume_name }}{{ item }}"
+    size: "{{ nodes_extra_volume_size }}"
+    state: present
+  when:
+  - state == "present"
+  - nodes_extra_volume
+  with_sequence: count={{ nodes_count }}
+
+- name: Attach data volumes to minions
+  os_server_volume:
+    state: present
+    server: "{{ nodes_name }}{{ item }}"
+    volume: "{{ nodes_extra_volume_name }}{{ item }}"
+  when:
+  - state == "present"
+  - nodes_extra_volume
+  with_sequence: count={{ nodes_count }}
+
 - name: Delete OpenStack instances
   os_server:
     name: "{{ nodes_name }}{{ item }}"
     state: absent
   when: state == "absent"
+  with_sequence: count={{ nodes_count }}
+
+- name: Delete data volumes
+  os_volume:
+    name: "{{ nodes_extra_volume_name }}{{ item }}"
+    state: absent
+  when:
+  - state == "absent"
+  - nodes_extra_volume
   with_sequence: count={{ nodes_count }}
 
 - name: Delete security group


### PR DESCRIPTION
Some clouds only offer boot-from-volume. To support those clouds, add
support for boot-from-volume.

Also, some workloads, such as running ceph in kubernetes using rook,
want an extra data volume on the node itself. Add some config options
for creating an extra unmounted data volume for each node, that default
to off.