### PR TITLE
Bump k8s version to 1.11.5

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -29,5 +29,5 @@ helm_repos: "{{ lookup('env', 'HELM_REPOS').split(';') | default([], true) }}"
 helm_install: "{{ lookup('env', 'HELM_INSTALL').split(';') | default([], true) }}"
 
 #Change at your own risk
-kubernetes_version: v1.11.1
-kubernetes_ubuntu_version: 1.11.1-00
+kubernetes_version: v1.11.5
+kubernetes_ubuntu_version: 1.11.5-00


### PR DESCRIPTION
There is a security issue fixed in 1.11.5. Go ahead and bump to it since
it's a minor version.