### PR TITLE
Add support for octavia

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following optional environment variables can also be set:
   * `EXTERNAL_NETWORK`: name of the neutron external network, defaults to 'public'
   * `FLOATING_IP_POOL`: name of the floating IP pool
   * `FLOATING_IP_NETWORK_UUID`: uuid of the floating IP network (required for LBaaSv2)
+  * `USE_OCTAVIA`: try to use Octavia instead of Neutron LBaaS, defaults to False
   * `NODE_MEMORY`: how many MB of memory should nodes have, defaults to 4GB
   * `NODE_FLAVOR`: allows to configure the exact OpenStack flavor name or ID to use for the nodes. When set, the `NODE_MEMORY` setting is ignored.
   * `NODE_COUNT`: how many nodes should we provision, defaults to 3

--- a/files/cloud-config.j2
+++ b/files/cloud-config.j2
@@ -28,6 +28,9 @@ lb-version = v2
 floating-network-id = {{ lookup('env', 'FLOATING_IP_NETWORK_UUID') }}
 subnet-id = {{ hostvars[groups.master[0]]['subnetuuid'] }}
 create-monitor = yes
+{% if hostvars[groups.master[0]]['use_octavia'] %}
+use-octavia = yes
+{% endif %}
 monitor-delay = 1m
 monitor-timeout = 30s
 monitor-max-retries = 3

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -7,6 +7,7 @@ subnet_name: "{{ lookup('env','NETWORK') | default(name, true) }}"
 router_name: "{{ lookup('env','NAME') | default(name, true) }}"
 floating_ip_pools: "{{ lookup('env', 'FLOATING_IP_POOL') | default(omit, true) }}"
 external_network_name: "{{ lookup('env', 'EXTERNAL_NETWORK') | default('public', true) }}"
+use_octavia: "{{ lookup('env', 'USE_OCTAVIA') | default('False', true) | bool }}"
 
 master_name: "{{ name }}-master"
 master_image: "{{ lookup('env','IMAGE') | default('xenial-server-cloudimg-amd64', true) }}"

--- a/roles/openstack-security-groups/tasks/main.yaml
+++ b/roles/openstack-security-groups/tasks/main.yaml
@@ -138,6 +138,17 @@
     remote_group: "sg-{{ name }}-master"
   when: state == "present"
 
+- name: Allow load balancer traffic to nodes
+  tags: bootstrap
+  os_security_group_rule:
+    security_group: "sg-{{ name }}-nodes"
+    remote_ip_prefix: 10.8.10.0/24
+    protocol: tcp
+    port_range_min: 30000
+    port_range_max: 32767
+  when:
+  - state == "present"
+  - use_octavia
 
 - name: Delete master security group
   tags: bootstrap


### PR DESCRIPTION
If the cloud uses octavia and not neutron lbaas, you need a flag in
cloud-config.

The k8s docs indicate that use-octavia will fall back to looking for
neutron-lbaas if it can't find octavia - maybe it would not be a
terrible idea to just default it to true?