### PR TITLE
More support for external volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The following optional environment variables can also be set:
   * `FLOATING_IP_POOL`: name of the floating IP pool
   * `FLOATING_IP_NETWORK_UUID`: uuid of the floating IP network (required for LBaaSv2)
   * `USE_OCTAVIA`: try to use Octavia instead of Neutron LBaaS, defaults to False
+  * `BLOCK_STORAGE_VERSION`: version of the block storage (Cinder) service, defaults to 'v2'
+  * `IGNORE_VOLUME_AZ`: whether to ignore the AZ field of volumes, needed on some clouds where AZs confuse the driver, defaults to False.
   * `NODE_MEMORY`: how many MB of memory should nodes have, defaults to 4GB
   * `NODE_FLAVOR`: allows to configure the exact OpenStack flavor name or ID to use for the nodes. When set, the `NODE_MEMORY` setting is ignored.
   * `NODE_COUNT`: how many nodes should we provision, defaults to 3

--- a/files/cloud-config.j2
+++ b/files/cloud-config.j2
@@ -20,7 +20,10 @@ domain-name = {{ lookup('env', 'OS_USER_DOMAIN_ID') }}
 
 [BlockStorage]
 trust-device-path = false
-bs-version = v2
+bs-version = {{ hostvars[groups.master[0]]['block_storage_version'] }}
+{% if hostvars[groups.master[0]]['ignore_volume_az'] %}
+ignore-volume-az = true
+{% endif %}
 
 {% if lookup('env', 'FLOATING_IP_NETWORK_UUID') != '' %}
 [LoadBalancer]

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -8,6 +8,8 @@ router_name: "{{ lookup('env','NAME') | default(name, true) }}"
 floating_ip_pools: "{{ lookup('env', 'FLOATING_IP_POOL') | default(omit, true) }}"
 external_network_name: "{{ lookup('env', 'EXTERNAL_NETWORK') | default('public', true) }}"
 use_octavia: "{{ lookup('env', 'USE_OCTAVIA') | default('False', true) | bool }}"
+block_storage_version: "{{ lookup('env', 'BLOCK_STORAGE_VERSION') | default('v2', true) }}"
+ignore_volume_az: "{{ lookup('env', 'IGNORE_VOLUME_AZ') | default('false', true) | bool }}"
 
 master_name: "{{ name }}-master"
 master_image: "{{ lookup('env','IMAGE') | default('xenial-server-cloudimg-amd64', true) }}"

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -25,7 +25,7 @@
 - name: Configure kube-controller-manager cloud provider integration Step1
   blockinfile:
     insertbefore: 'image: '
-    block: "    - --cloud-provider=external\n    - --cluster-cidr=10.96.0.0/16\n    - --allocate-node-cidrs=true"
+    block: "    - --cloud-provider=external\n    - --cluster-cidr=10.96.0.0/16\n    - --allocate-node-cidrs=true\n    - --external-cloud-volume-plugin=openstack\n    - --cloud-config=/etc/kubernetes/cloud-config"
     path: /etc/kubernetes/manifests/kube-controller-manager.yaml
     marker: "# {mark} ANSIBLE MANAGED BLOCK CLOUDPROVIDER"
 
@@ -55,11 +55,25 @@
     regexp: '.*--authorization-mode=.*'
     line: "    - --authorization-mode=Node,Webhook,RBAC"
 
-- name: Configure keystone integration
+- name: Configure apiserver cloud provider integration
   blockinfile:
     insertbefore: 'image: '
-    block: "    - --authentication-token-webhook-config-file=/etc/kubernetes/pki/webhook.kubeconfig.yaml\n    - --authorization-webhook-config-file=/etc/kubernetes/pki/webhook.kubeconfig.yaml"
+    block: "    - --authentication-token-webhook-config-file=/etc/kubernetes/pki/webhook.kubeconfig.yaml\n    - --authorization-webhook-config-file=/etc/kubernetes/pki/webhook.kubeconfig.yaml\n    - --cloud-provider=external"
     path: /etc/kubernetes/manifests/kube-apiserver.yaml
+
+- name: Configure apiserver cloud provider integration Step2
+  blockinfile:
+    insertafter: 'volumeMounts:'
+    block: "    - mountPath: /etc/kubernetes/cloud-config\n      name: cloud-config\n      readOnly: true"
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    marker: "# {mark} ANSIBLE MANAGED BLOCK CLOUDCONFIG"
+
+- name: Configure apiserver cloud provider integration Step3
+  blockinfile:
+    insertbefore: 'status: '
+    block: "  - hostPath:\n      path: /etc/kubernetes/cloud-config\n      type: FileOrCreate\n    name: cloud-config"
+    path: /etc/kubernetes/manifests/kube-apiserver.yaml
+    marker: "# {mark} ANSIBLE MANAGED BLOCK HOSTPATH"
 
 - name: In case of upgrade make sure container versions are right for kube-apiserver
   replace:


### PR DESCRIPTION
The original PR was busted due to one of the tasks being applied to the wrong file- and a stray `-`. I had fixed them on my laptop and thought I'd pushed up the fix to GH, but clearly I was wrong about that. Sorry.

This one has run against my k8s deploy successfully now.

This also exposes two settings needed in some cases - being able to set the API version for cinder, and being able to set the ignore_volume_az flag. (it has been suggested to just always set that flag to true - but leaving it unset is working for me on the single-az cloud I'm using.