### PR TITLE
Update ssh known_hosts handling

### DIFF
--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -24,7 +24,7 @@ nodes_name: "{{ name }}-" # node id will automatically be appended
 nodes_image: "{{ lookup('env','IMAGE') | default('xenial-server-cloudimg-amd64', true) }}"
 nodes_flavor_ram: "{{ lookup('env','NODE_MEMORY') | default('4096', true) }}"
 nodes_flavor_name: "{{ lookup('env','NODE_FLAVOR') | default(false) }}"
-nodes_auto_ip: "{{ lookup('env', 'NODE_AUTO_IP') | default ('False', true) }}"
+nodes_auto_ip: "{{ lookup('env', 'NODE_AUTO_IP') | default ('False', true) }} | bool"
 nodes_delete_fip: "{{ lookup('env', 'NODE_DELETE_FIP') | default ('True', true) }}"
 # Some clouds only support boot from volume - use it even for ephemeral nodes
 nodes_boot_from_volume: "{{ lookup('env', 'NODE_BOOT_FROM_VOLUME') | default('False', true) }}"

--- a/roles/openstack-master/tasks/main.yaml
+++ b/roles/openstack-master/tasks/main.yaml
@@ -51,6 +51,10 @@
     search_regex: OpenSSH
   when: state == "present"
 
-- name: Allow SSH keys on first connection
-  shell: "ssh-keyscan {{ instance.openstack.accessIPv4 }} >> ~/.ssh/known_hosts"
+- name: Allow SSH keys if we don't have them already
+  lineinfile:
+    dest: ~/.ssh/known_hosts
+    create: yes
+    state: present
+    line: "{{ lookup('pipe', 'ssh-keyscan ' + instance.openstack.accessIPv4) }}"
   when: state == "present"

--- a/roles/openstack-master/tasks/main.yaml
+++ b/roles/openstack-master/tasks/main.yaml
@@ -36,7 +36,7 @@
 - name: Update inventory
   add_host:
     name: "{{ instance.server.name }}"
-    ansible_ssh_host: "{{ instance.openstack.accessIPv4 }}"
+    ansible_ssh_host: "{{ instance.openstack.public_v4 }}"
     ansible_ssh_user: ubuntu
     groupname: master
     routeruuid: "{{ routeruuid | default('None',true) }}"
@@ -46,7 +46,7 @@
 - name: Wait during instances boot
   tags: bootstrap
   wait_for:
-    host: "{{ instance.openstack.accessIPv4 }}"
+    host: "{{ instance.openstack.public_v4 }}"
     port: 22
     search_regex: OpenSSH
   when: state == "present"
@@ -56,5 +56,5 @@
     dest: ~/.ssh/known_hosts
     create: yes
     state: present
-    line: "{{ lookup('pipe', 'ssh-keyscan ' + instance.openstack.accessIPv4) }}"
+    line: "{{ lookup('pipe', 'ssh-keyscan ' + instance.openstack.public_v4 ) }}"
   when: state == "present"

--- a/roles/openstack-nodes/tasks/main.yaml
+++ b/roles/openstack-nodes/tasks/main.yaml
@@ -72,7 +72,7 @@
     state: absent
   when: state == "absent"
 
-- name: Update inventory
+- name: Update inventory for private IP
   add_host:
     name: "{{ item.server.name }}"
     ansible_ssh_host: "{{ item.server.private_v4 }}"
@@ -80,7 +80,20 @@
     ansible_ssh_common_args: "-o ProxyCommand=\"ssh -W %h:%p -q ubuntu@{{ hostvars[groups.master[0]]['ansible_ssh_host'] }}\""
     groupname: nodes
   with_items: "{{ instances.results }}"
-  when: state == "present"
+  when:
+  - state == "present"
+  - not nodes_auto_ip
+
+- name: Update inventory with public IP
+  add_host:
+    name: "{{ item.server.name }}"
+    ansible_ssh_host: "{{ item.server.public_v4 }}"
+    ansible_ssh_user: ubuntu
+    groupname: nodes
+  with_items: "{{ instances.results }}"
+  when:
+  - state == "present"
+  - nodes_auto_ip
 
 - name: Wait during nodes boot
   wait_for:


### PR DESCRIPTION
There are three related changes here.

The first updates the master to be similar to the nodes and use lineinfile to add ssh keys to known_hosts instead of just shell redirection, otherwise known_hosts just grows over time.

The second updates nodes to use public ip instead of private ip with a proxy when auto_ip is True. This let's people who are intending to connect to those nodes directly from the machine they're running ansible from be set up to do so.

Finally, updated references to accesIPv4 to use public_v4 instead, as public_v4 is a stable interface from openstacksdk.