### PR TITLE
Fix issue with nginx-ingress and external-dns

### DIFF
--- a/files/cloud-config.j2
+++ b/files/cloud-config.j2
@@ -33,11 +33,10 @@ subnet-id = {{ hostvars[groups.master[0]]['subnetuuid'] }}
 create-monitor = yes
 {% if hostvars[groups.master[0]]['use_octavia'] %}
 use-octavia = yes
+{% else %}
+use-octavia = no
 {% endif %}
 monitor-delay = 1m
 monitor-timeout = 30s
 monitor-max-retries = 3
 {% endif %}
-
-[Route]
-router-id = {{ hostvars[groups.master[0]]['routeruuid'] }}

--- a/files/kubeadm-init.yaml.j2
+++ b/files/kubeadm-init.yaml.j2
@@ -6,21 +6,11 @@ nodeRegistration:
   kubeletExtraArgs:
     cgroup-driver: systemd
     cloud-provider: external
-    network-plugin: kubenet
+    network-plugin: cni
     cluster-dns: "{{ cluster_dns_ip }}"
     # non-masquerade-cidr: 0.0.0.0/0 # from https://medium.com/elotl-blog/kubernetes-networking-on-aws-part-i-99012e938a40
 localAPIEndpoint:
   advertiseAddress: "{{ hostvars[groups.master[0]].ansible_ssh_host }}"
-
-# This is ignored by kubeadm (because we are joining using a token, this excludes the use of JoinConfiguration)
-# see kubeadm-nodes/main.yaml for a hack to heal this issue
-#---
-#apiVersion: kubeadm.k8s.io/v1beta2
-#kind: JoinConfiguration
-#nodeRegistration:
-#  kubeletExtraArgs:
-#    cloud-provider: external
-#    network-plugin: kubenet
 
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -47,7 +47,7 @@ helm_install: "{{ lookup('env', 'HELM_INSTALL').split(';') | default([], true) }
 availability_zone: "{{ lookup('env','AVAILABILITY_ZONE') | default('nova', true) }}"
 
 #Change at your own risk
-kubernetes_version: v1.15.2
-kubernetes_ubuntu_version: 1.15.2-00
-kubernetes_cni_ubuntu_version: 0.7.5-00
-docker_version: 18.09.7-0ubuntu1~18.04.4
+kubernetes_version: v1.18.0
+kubernetes_ubuntu_version: 1.18.3-00 # Run apt-cache madison kubelet to get available versions
+kubernetes_cni_ubuntu_version: 0.7.5-00 # Run apt-cache madison kubernetes-cni to get available versions
+docker_version: 19.03.8-0ubuntu1

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -47,7 +47,12 @@ helm_install: "{{ lookup('env', 'HELM_INSTALL').split(';') | default([], true) }
 availability_zone: "{{ lookup('env','AVAILABILITY_ZONE') | default('nova', true) }}"
 
 #Change at your own risk
-kubernetes_version: v1.18.0
-kubernetes_ubuntu_version: 1.18.3-00 # Run apt-cache madison kubelet to get available versions
-kubernetes_cni_ubuntu_version: 0.7.5-00 # Run apt-cache madison kubernetes-cni to get available versions
-docker_version: 19.03.8-0ubuntu1
+kubernetes_version: v1.16.10
+kubernetes_ubuntu_version: 1.16.10-00
+kubernetes_cni_ubuntu_version: 0.7.5-00
+docker_version: 18.09.7-0ubuntu1~18.04.4
+#Currently not working:
+#kubernetes_version: v1.18.0
+#kubernetes_ubuntu_version: 1.18.3-00 # Run apt-cache madison kubelet to get available versions
+#kubernetes_cni_ubuntu_version: 0.7.5-00 # Run apt-cache madison kubernetes-cni to get available versions
+#docker_version: 19.03.8-0ubuntu1

--- a/roles/global-handlers/handlers/main.yaml
+++ b/roles/global-handlers/handlers/main.yaml
@@ -1,16 +1,16 @@
 - name: Restart kubelet
   systemd:
-      state: restarted
-      daemon_reload: yes
-      name: kubelet
+    state: restarted
+    daemon_reload: yes
+    name: kubelet
 
 - name: Restart docker
   systemd:
-      state: restarted
-      daemon_reload: yes
-      name: docker
+    state: restarted
+    daemon_reload: yes
+    name: docker
 
 - name: Restart rsyslog
   service:
-      name: rsyslog
-      state: restarted
+    name: rsyslog
+    state: restarted

--- a/roles/k8s-addons/tasks/nginx-ingress.yaml
+++ b/roles/k8s-addons/tasks/nginx-ingress.yaml
@@ -17,5 +17,5 @@
   when: k8s_ingress_status.rc != 0
 
 - name: k8s - Install nginx-ingress via helm
-  shell: 'helm install --namespace {{ k8s_ingress_namespace }} --set ''controller.extraArgs.default-ssl-certificate=cert-manager/ingress-certificate-secret'' --set ''controller.config.proxy-body-size="0"'' --set ''controller.publishService.enabled=true'' --set ''controller.image.tag=0.25.1'' ''{{ k8s_ingress_release_name }}'' ''stable/nginx-ingress'''
+  shell: "helm install --namespace {{ k8s_ingress_namespace }} --set 'controller.extraArgs.default-ssl-certificate=cert-manager/ingress-certificate-secret' --set-string 'controller.config.proxy-body-size=0' --set 'controller.publishService.enabled=true' '{{ k8s_ingress_release_name }}' 'stable/nginx-ingress'"
   when: k8s_ingress_status.rc != 0

--- a/roles/k8s-addons/tasks/nginx-ingress.yaml
+++ b/roles/k8s-addons/tasks/nginx-ingress.yaml
@@ -17,5 +17,5 @@
   when: k8s_ingress_status.rc != 0
 
 - name: k8s - Install nginx-ingress via helm
-  shell: "helm install --namespace {{ k8s_ingress_namespace }} --set 'controller.extraArgs.default-ssl-certificate=cert-manager/ingress-certificate-secret' --set 'controller.publishService.enabled=true' --set 'controller.image.tag=0.25.1' '{{ k8s_ingress_release_name }}' 'stable/nginx-ingress'"
+  shell: 'helm install --namespace {{ k8s_ingress_namespace }} --set ''controller.extraArgs.default-ssl-certificate=cert-manager/ingress-certificate-secret'' --set ''controller.config.proxy-body-size="0"'' --set ''controller.publishService.enabled=true'' --set ''controller.image.tag=0.25.1'' ''{{ k8s_ingress_release_name }}'' ''stable/nginx-ingress'''
   when: k8s_ingress_status.rc != 0

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -117,7 +117,6 @@
   when: state == "present"
 
 - name: Copy kubectl configuration for the default user
-  become: True
   copy:
     remote_src: True
     src: /etc/kubernetes/admin.conf
@@ -137,6 +136,9 @@
   when:
     - state == "present"
 
+# ----------------------------------------------------------------------------------
+# Convenience tools (bash completion, kubectx, kubens)
+# ----------------------------------------------------------------------------------
 - name: Check for existing kubectl bash completion
   stat:
     path: /etc/bash_completion.d/kubectl

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -47,6 +47,10 @@
     - state == "absent"
     - kubelet_conf.stat.exists == True
 
+# ----------------------------------------------------------------------------------
+# Create join token
+# ----------------------------------------------------------------------------------
+
 - name: Generate a join token
   command: kubeadm token create --print-join-command
   register: joincommand
@@ -56,6 +60,10 @@
   set_fact:
     joincommand: "{{ joincommand.stdout }}"
   when: state == "present"
+
+# ----------------------------------------------------------------------------------
+# In case of upgrade: update versions in config files
+# ----------------------------------------------------------------------------------
 
 - name: In case of upgrade make sure container versions are right for kube-apiserver
   replace:

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -127,6 +127,16 @@
     mode: 0600
   when: state == "present"
 
+# ----------------------------------------------------------------------------------
+# Install calico CNI
+# cf. https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#pod-network
+# ----------------------------------------------------------------------------------
+
+- name: Install Calico CNI
+  command: "kubectl apply -f https://docs.projectcalico.org/v3.14/manifests/calico.yaml"
+  when:
+    - state == "present"
+
 - name: Check for existing kubectl bash completion
   stat:
     path: /etc/bash_completion.d/kubectl

--- a/roles/kubeadm-master/tasks/main.yaml
+++ b/roles/kubeadm-master/tasks/main.yaml
@@ -86,8 +86,28 @@
     replace: "{{ kubernetes_version }}"
   when: state == "present"
 
+# ----------------------------------------------------------------------------------
+# Copy kubeconf to appropriate locations
+# ----------------------------------------------------------------------------------
+
 - name: Ensure kubectl configuration directory is present
-  become: True
+  file:
+    path: /root/.kube
+    state: directory
+    owner: root
+    mode: 0700
+  when: state == "present"
+
+- name: Copy kubectl configuration for the root user
+  copy:
+    remote_src: True
+    src: /etc/kubernetes/admin.conf
+    dest: /root/.kube/config
+    owner: root
+    mode: 0600
+  when: state == "present"
+
+- name: Ensure kubectl configuration directory is present
   file:
     path: /home/ubuntu/.kube
     state: directory

--- a/roles/kubeadm-nodes/tasks/main.yaml
+++ b/roles/kubeadm-nodes/tasks/main.yaml
@@ -15,13 +15,3 @@
   command: "kubeadm reset --force"
   when: state == "absent"
   ignore_errors: True
-
-# For some reason "kubeadm join" does not write the correct value here
-- name: HACK - replace --network-plugin=cni with --network-plugin=kubenet
-  replace:
-    path: /var/lib/kubelet/kubeadm-flags.env
-    regexp: network-plugin=cni
-    replace: "network-plugin=kubenet"
-  notify:
-    - Restart kubelet
-  when: state == "present"

--- a/roles/kubeadm/tasks/main.yaml
+++ b/roles/kubeadm/tasks/main.yaml
@@ -1,3 +1,6 @@
+--- # ---------------------------------------------------------
+# ---------------------------------------------------------
+# Add package repos
 - name: Install k8s APT repo GPG key
   apt_key:
     url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
@@ -12,62 +15,79 @@
 # Check installed package versions
 # ---------------------------------------------------------
 
+- name: Set packages and their desired versions to be installed
+  set_fact:
+    desired_package_versions:
+      docker.io: "{{ docker_version }}"
+      kubelet: "{{ kubernetes_ubuntu_version }}"
+      kubeadm: "{{ kubernetes_ubuntu_version }}"
+      kubectl: "{{ kubernetes_ubuntu_version }}"
+      kubernetes-cni: "{{ kubernetes_cni_ubuntu_version }}"
+
 - name: Gather apt package facts
   package_facts:
     manager: apt
 
-- name: Check kubectl installed
+- name: Populate versions (for installed packages)
   set_fact:
-    kubelet_installed: false
-  when: "'kubelet' not in ansible_facts.packages"
+    installed_versions: "{{ installed_versions|default({}) | combine( {item.key: ansible_facts.packages[item.key][0].version} ) }}"
+  when: "item.key in ansible_facts.packages"
+  loop: "{{ lookup('dict', desired_package_versions) }}"
 
-- name: Get version of kubelet
+- name: Populate versions (for missing packages)
   set_fact:
-    kubelet_installed_version: "{{ ansible_facts.packages['kubelet'][0].version }}"
-    kubelet_installed: true
-  when: "'kubelet' in ansible_facts.packages"
+    installed_versions: "{{ installed_versions|default({}) | combine( {item.key: '__not__installed__'} ) }}"
+  when: "item.key not in ansible_facts.packages"
+  loop: "{{ lookup('dict', desired_package_versions) }}"
 
-- name: Print kubelet version package facts
+- name: Get packages on hold
+  command: apt-mark showhold
+  register: packages_on_hold
+  changed_when: false # This doesn't influence idempotency
+
+# Unhold and install correct version
+- name: Unholding packages that require change (install or change version)
+  command: "apt-mark unhold {{ item.key }}"
+  # versions do not match, item.key = package name, item.value = current version, desired_package_versions[item.key] = desired version
+  when: "item.value != desired_package_versions[item.key]"
+  loop: "{{ lookup('dict', installed_versions) }}"
+
+- name: Compile a list of "name=version" tuples to be installed
+  set_fact:
+    apt_install_list: "{{ (apt_install_list | default([])) + [item.key + '=' +  desired_package_versions[item.key]] }}"
+  when: "item.value != desired_package_versions[item.key]"
+  loop: "{{ lookup('dict', installed_versions) }}"
+
+- name: Packages to be installed
   debug:
-    var: kubelet_installed_version
+    var: apt_install_list
+  when: apt_install_list is defined
 
-# TODO Make this idempotent (cf. https://github.com/ansible/ansible/issues/18889)
-- name: Unhold docker and kubernetes packages
-  command: "apt-mark unhold {{ item }}"
-  with_items:
-    - docker.io
-    - kubelet
-    - kubeadm
-    - kubectl
-    - kubernetes-cni
-
-- name: Install docker and kubernetes packages
+- name: Installing packages that require change (install or change version)
   apt:
-    name:
-      [
-        "docker.io={{ docker_version }}",
-        "kubelet={{ kubernetes_ubuntu_version }}",
-        "kubeadm={{ kubernetes_ubuntu_version }}",
-        "kubectl={{ kubernetes_ubuntu_version }}",
-        "kubernetes-cni={{ kubernetes_cni_ubuntu_version }}",
-      ]
+    name: "{{ apt_install_list }}"
     state: present
+    only_upgrade: no
+    force: true
     update_cache: yes
+  # versions do not match, item.key = package name, item.value = current version, desired_package_versions[item.key] = desired version
+  when: apt_install_list is defined
+
+- name: Holding packages that required change (install or change version)
+  command: "apt-mark hold {{ item.key }}"
+  # versions didn't match or package hasn't been on hold yet
+  when: "item.value != desired_package_versions[item.key] or item.key not in packages_on_hold.stdout_lines"
+  loop: "{{ lookup('dict', installed_versions) }}"
+
+# ---------------------------------------------------------
+# Configure docker.io
+# ---------------------------------------------------------
 
 - name: Enable docker service
   systemd:
     name: docker
     enabled: yes
     daemon_reload: yes
-
-- name: Hold docker and kubernetes packages
-  command: "apt-mark hold {{ item }}"
-  with_items:
-    - docker.io
-    - kubelet
-    - kubeadm
-    - kubectl
-    - kubernetes-cni
 
 - name: configure docker to use journald
   copy:
@@ -90,6 +110,10 @@
   notify:
     - Restart docker
 
+# ---------------------------------------------------------
+# Add hostnames to /etc/hosts
+# ---------------------------------------------------------
+
 - name: add hosts
   lineinfile:
     dest: "/etc/hosts"
@@ -98,6 +122,10 @@
     state: present
   when: hostvars[item].ansible_hostname is defined
   with_items: "{{groups['all'] | default([])}}"
+
+# ---------------------------------------------------------
+# OpenStack cloud configuration
+# ---------------------------------------------------------
 
 - name: Create OpenStack cloud configuration
   template:
@@ -118,7 +146,7 @@
 # https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/
 # ---------------------------------------------------------
 
-# TODO: load module br_netfilter)
+# TODO: load module br_netfilter
 
 - name: Let iptables see bridged traffic
   copy:

--- a/roles/kubeadm/tasks/main.yaml
+++ b/roles/kubeadm/tasks/main.yaml
@@ -73,11 +73,15 @@
   copy:
     content: |
       {
-        "exec-opts": [
-          "native.cgroupdriver=systemd"
-        ],
-        "log-driver": "journald",
-        "storage-driver": "overlay2"
+        "exec-opts": ["native.cgroupdriver=systemd"],
+        "log-driver": "json-file",
+        "log-opts": {
+          "max-size": "100m"
+        },
+        "storage-driver": "overlay2",
+        "storage-opts": [
+          "overlay2.override_kernel_check=true"
+        ]
       }
     dest: /etc/docker/daemon.json
     owner: root
@@ -85,18 +89,6 @@
     mode: 0644
   notify:
     - Restart docker
-
-- name: dont write docker logs to /var/log/syslog
-  copy:
-    content: |
-      if $programname == 'dockerd' or $syslogtag == 'dockerd' then /dev/null
-      & stop
-    dest: "/etc/rsyslog.d/30-docker.conf"
-    mode: 0644
-    owner: root
-    group: root
-  notify:
-    - Restart rsyslog
 
 - name: add hosts
   lineinfile:

--- a/roles/kubeadm/tasks/main.yaml
+++ b/roles/kubeadm/tasks/main.yaml
@@ -8,6 +8,29 @@
     repo: deb http://apt.kubernetes.io/ kubernetes-xenial main
     state: present
 
+# ---------------------------------------------------------
+# Check installed package versions
+# ---------------------------------------------------------
+
+- name: Gather apt package facts
+  package_facts:
+    manager: apt
+
+- name: Check kubectl installed
+  set_fact:
+    kubelet_installed: false
+  when: "'kubelet' not in ansible_facts.packages"
+
+- name: Get version of kubelet
+  set_fact:
+    kubelet_installed_version: "{{ ansible_facts.packages['kubelet'][0].version }}"
+    kubelet_installed: true
+  when: "'kubelet' in ansible_facts.packages"
+
+- name: Print kubelet version package facts
+  debug:
+    var: kubelet_installed_version
+
 # TODO Make this idempotent (cf. https://github.com/ansible/ansible/issues/18889)
 - name: Unhold docker and kubernetes packages
   command: "apt-mark unhold {{ item }}"

--- a/roles/kubeadm/tasks/main.yaml
+++ b/roles/kubeadm/tasks/main.yaml
@@ -112,3 +112,23 @@
     mode: 0600
   notify:
     - Restart kubelet
+
+# ---------------------------------------------------------
+# Ensure all prerequisites are met
+# https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/
+# ---------------------------------------------------------
+
+# TODO: load module br_netfilter)
+
+- name: Let iptables see bridged traffic
+  copy:
+    dest: /etc/sysctl.d/k8s.conf
+    owner: root
+    group: root
+    mode: 0644
+    content: |
+      net.bridge.bridge-nf-call-ip6tables = 1
+      net.bridge.bridge-nf-call-iptables = 1
+
+- name: Let iptables see bridged traffic (load settings from all system configuration files)
+  command: "sysctl --system"

--- a/site.yaml
+++ b/site.yaml
@@ -118,6 +118,7 @@
   hosts: master
   tags:
     - bootstrap
+    - k8s-addons
   roles:
     - k8s-addons
 

--- a/site.yaml
+++ b/site.yaml
@@ -66,27 +66,6 @@
   roles:
     - kubeadm
 
-# ------------------------------- START WORKAROUNDS ----------------------------------------
-
-#- name: WORKAROUND for iptables >= 1.8, cf. https://github.com/kubernetes/kubernetes/issues/71305
-#  hosts: all
-#  tasks:
-#    - name: bla
-#      shell: |
-#        update-alternatives --set iptables /usr/sbin/iptables-legacy
-#        update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-#        update-alternatives --set arptables /usr/sbin/arptables-legacy
-#        update-alternatives --set ebtables /usr/sbin/ebtables-legacy
-
-- name: WORKAROUND for networking to work with kubenet
-  hosts: all
-  become: true
-  tasks:
-    - name: Set policy ACCEPT on chain FORWARD (cf. https://github.com/projectcalico/calico/issues/1840)
-      shell: iptables -P FORWARD ACCEPT
-
-# ------------------------------- END WORKAROUNDS ----------------------------------------
-
 - name: k8s master setup
   hosts: master
   tags:


### PR DESCRIPTION
This fixes error "No endpoints could be generated from ingress" with nginx-ingress and external-dns (cf. https://github.com/kubernetes-sigs/external-dns/issues/456). 

In addition, it disables the maximum body size for NGINX ingress to avoid getting error "413 Request Entity Too Large" when, e.g., pushing docker images to a docker registry hosted in k8s.

