### PR TITLE
Update helm repo url

### DIFF
--- a/roles/k8s-addons/tasks/helm.yaml
+++ b/roles/k8s-addons/tasks/helm.yaml
@@ -10,7 +10,7 @@
 
 # Not added by default with Helm v3 (required for nginx-ingress)
 - name: add repos to helm
-  command: "helm repo add stable https://kubernetes-charts.storage.googleapis.com"
+  command: "helm repo add stable https://charts.helm.sh/stable"
 
 - name: update the helm repos
   command: helm repo update

--- a/roles/k8s-addons/tasks/nginx-ingress.yaml
+++ b/roles/k8s-addons/tasks/nginx-ingress.yaml
@@ -9,7 +9,7 @@
   register: k8s_ingress_status
 
 - name: Add stable repo to helm
-  shell: "helm repo add stable https://kubernetes-charts.storage.googleapis.com"
+  shell: "helm repo add stable https://charts.helm.sh/stable"
   when: k8s_ingress_status.rc != 0
 
 - name: Update helm repos


### PR DESCRIPTION
Since the url "https://kubernetes-charts.storage.googleapis.com" is
no longer available update it to "https://charts.helm.sh/stable"

Signed-off-by: Yadnesh Kulkarni <ykulkarn@redhat.com>